### PR TITLE
Vue Dapp v1 (work in progress)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vue-dapp/core",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"description": "",
 	"type": "module",
 	"files": [
@@ -25,16 +25,20 @@
 	},
 	"license": "MIT",
 	"dependencies": {
-		"pinia": "^2.1.7",
-		"tiny-invariant": "^1.3.1",
-		"vue": "^3.3.7"
+		"tiny-invariant": "^1.3.1"
 	},
 	"devDependencies": {
 		"@vitejs/plugin-vue": "^4.4.0",
+		"pinia": "^2.1.7",
 		"typescript": "5.1.3",
 		"vite": "^4.5.0",
 		"vite-plugin-dts": "^3.6.2",
 		"vitest": "0.28.5",
+		"vue": "^3.3.7",
 		"vue-tsc": "^0.29.8"
+	},
+	"peerDependencies": {
+		"pinia": "^2.1.7",
+		"vue": "^3.3.7"
 	}
 }

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
 			output: {
 				dir: 'dist',
 				globals: {
-					vue: 'Vue',
+					vue: 'vue',
 					pinia: 'pinia',
 				},
 			},

--- a/packages/vd-board/package.json
+++ b/packages/vd-board/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@vue-dapp/vd-board",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"type": "module",
 	"files": [
 		"dist"
@@ -22,17 +22,20 @@
 		"build": "vite build",
 		"preview": "vite preview"
 	},
-	"dependencies": {
-		"@vue-dapp/core": "workspace:^",
-		"pinia": "^2.1.7",
-		"vue": "^3.3.6"
-	},
 	"devDependencies": {
 		"@vitejs/plugin-vue": "^4.4.0",
+		"@vue-dapp/core": "workspace:^",
+		"pinia": "^2.1.7",
 		"typescript": "^5.1.3",
 		"vite": "^4.5.0",
 		"vite-plugin-dts": "^3.6.2",
 		"vite-plugin-style-inject": "^0.0.1",
+		"vue": "^3.3.6",
 		"vue-tsc": "^0.29.8"
+	},
+	"peerDependencies": {
+		"@vue-dapp/core": "workspace:^",
+		"pinia": "^2.1.7",
+		"vue": "^3.3.6"
 	}
 }

--- a/packages/vd-board/vite.config.ts
+++ b/packages/vd-board/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
 			output: {
 				dir: 'dist',
 				globals: {
-					vue: 'Vue',
+					vue: 'vue',
 					pinia: 'pinia',
 					'@vue-dapp/core': 'core',
 				},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,19 +275,16 @@ importers:
 
   packages/core:
     dependencies:
-      pinia:
-        specifier: ^2.1.7
-        version: 2.1.7(typescript@5.1.3)(vue@3.3.7)
       tiny-invariant:
         specifier: ^1.3.1
         version: 1.3.1
-      vue:
-        specifier: ^3.3.7
-        version: 3.3.7(typescript@5.1.3)
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: ^4.4.0
         version: 4.4.0(vite@4.5.0)(vue@3.3.7)
+      pinia:
+        specifier: ^2.1.7
+        version: 2.1.7(typescript@5.1.3)(vue@3.3.7)
       typescript:
         specifier: 5.1.3
         version: 5.1.3
@@ -300,6 +297,9 @@ importers:
       vitest:
         specifier: 0.28.5
         version: 0.28.5(jsdom@20.0.3)
+      vue:
+        specifier: ^3.3.7
+        version: 3.3.7(typescript@5.1.3)
       vue-tsc:
         specifier: ^0.29.8
         version: 0.29.8(typescript@5.1.3)
@@ -4342,6 +4342,7 @@ packages:
       '@vue/shared': 3.3.7
       estree-walker: 2.0.2
       source-map-js: 1.0.2
+    dev: true
 
   /@vue/compiler-dom@3.3.6:
     resolution: {integrity: sha512-1MxXcJYMHiTPexjLAJUkNs/Tw2eDf2tY3a0rL+LfuWyiKN2s6jvSwywH3PWD8bKICjfebX3GWx2Os8jkRDq3Ng==}
@@ -4354,6 +4355,7 @@ packages:
     dependencies:
       '@vue/compiler-core': 3.3.7
       '@vue/shared': 3.3.7
+    dev: true
 
   /@vue/compiler-sfc@3.3.6:
     resolution: {integrity: sha512-/Kms6du2h1VrXFreuZmlvQej8B1zenBqIohP0690IUBkJjsFvJxY0crcvVRJ0UhMgSR9dewB+khdR1DfbpArJA==}
@@ -4382,6 +4384,7 @@ packages:
       magic-string: 0.30.5
       postcss: 8.4.31
       source-map-js: 1.0.2
+    dev: true
 
   /@vue/compiler-ssr@3.3.6:
     resolution: {integrity: sha512-QTIHAfDCHhjXlYGkUg5KH7YwYtdUM1vcFl/FxFDlD6d0nXAmnjizka3HITp8DGudzHndv2PjKVS44vqqy0vP4w==}
@@ -4394,6 +4397,7 @@ packages:
     dependencies:
       '@vue/compiler-dom': 3.3.7
       '@vue/shared': 3.3.7
+    dev: true
 
   /@vue/devtools-api@6.5.1:
     resolution: {integrity: sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA==}
@@ -4453,6 +4457,7 @@ packages:
       '@vue/shared': 3.3.7
       estree-walker: 2.0.2
       magic-string: 0.30.5
+    dev: true
 
   /@vue/reactivity@3.3.6:
     resolution: {integrity: sha512-gtChAumfQz5lSy5jZXfyXbKrIYPf9XEOrIr6rxwVyeWVjFhJwmwPLtV6Yis+M9onzX++I5AVE9j+iPH60U+B8Q==}
@@ -4463,6 +4468,7 @@ packages:
     resolution: {integrity: sha512-cZNVjWiw00708WqT0zRpyAgduG79dScKEPYJXq2xj/aMtk3SKvL3FBt2QKUlh6EHBJ1m8RhBY+ikBUzwc7/khg==}
     dependencies:
       '@vue/shared': 3.3.7
+    dev: true
 
   /@vue/runtime-core@3.3.6:
     resolution: {integrity: sha512-qp7HTP1iw1UW2ZGJ8L3zpqlngrBKvLsDAcq5lA6JvEXHmpoEmjKju7ahM9W2p/h51h0OT5F2fGlP/gMhHOmbUA==}
@@ -4475,6 +4481,7 @@ packages:
     dependencies:
       '@vue/reactivity': 3.3.7
       '@vue/shared': 3.3.7
+    dev: true
 
   /@vue/runtime-dom@3.3.6:
     resolution: {integrity: sha512-AoX3Cp8NqMXjLbIG9YR6n/pPLWE9TiDdk6wTJHFnl2GpHzDFH1HLBC9wlqqQ7RlnvN3bVLpzPGAAH00SAtOxHg==}
@@ -4489,6 +4496,7 @@ packages:
       '@vue/runtime-core': 3.3.7
       '@vue/shared': 3.3.7
       csstype: 3.1.2
+    dev: true
 
   /@vue/server-renderer@3.3.6(vue@3.3.6):
     resolution: {integrity: sha512-kgLoN43W4ERdZ6dpyy+gnk2ZHtcOaIr5Uc/WUP5DRwutgvluzu2pudsZGoD2b7AEJHByUVMa9k6Sho5lLRCykw==}
@@ -4507,12 +4515,14 @@ packages:
       '@vue/compiler-ssr': 3.3.7
       '@vue/shared': 3.3.7
       vue: 3.3.7(typescript@5.1.3)
+    dev: true
 
   /@vue/shared@3.3.6:
     resolution: {integrity: sha512-Xno5pEqg8SVhomD0kTSmfh30ZEmV/+jZtyh39q6QflrjdJCXah5lrnOLi9KB6a5k5aAHXMXjoMnxlzUkCNfWLQ==}
 
   /@vue/shared@3.3.7:
     resolution: {integrity: sha512-N/tbkINRUDExgcPTBvxNkvHGu504k8lzlNQRITVnm6YjOjwa4r0nnbd4Jb01sNpur5hAllyRJzSK5PvB9PPwRg==}
+    dev: true
 
   /@vue/test-utils@2.4.1(vue@3.3.6):
     resolution: {integrity: sha512-VO8nragneNzUZUah6kOjiFmD/gwRjUauG9DROh6oaOeFwX1cZRUNHhdeogE8635cISigXFTtGLUQWx5KCb0xeg==}
@@ -11807,7 +11817,7 @@ packages:
       typescript: 5.1.3
       vue: 3.3.7(typescript@5.1.3)
       vue-demi: 0.14.6(vue@3.3.7)
-    dev: false
+    dev: true
 
   /pinia@2.1.7(typescript@5.2.2)(vue@3.3.6):
     resolution: {integrity: sha512-+C2AHFtcFqjPih0zpYuvof37SFxMQ7OEG2zV9jRI12i9BOy3YQVAHwdKtyyc8pDcDyIc33WCIsZaCFWU7WWxGQ==}
@@ -14570,6 +14580,7 @@ packages:
     resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
     engines: {node: '>=14.17'}
     hasBin: true
+    dev: true
 
   /typescript@5.2.2:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
@@ -15646,7 +15657,7 @@ packages:
         optional: true
     dependencies:
       vue: 3.3.7(typescript@5.1.3)
-    dev: false
+    dev: true
 
   /vue-devtools-stub@0.1.0:
     resolution: {integrity: sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==}
@@ -15749,6 +15760,7 @@ packages:
       '@vue/server-renderer': 3.3.7(vue@3.3.7)
       '@vue/shared': 3.3.7
       typescript: 5.1.3
+    dev: true
 
   /w3c-xmlserializer@4.0.0:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -438,20 +438,16 @@ importers:
         version: 0.25.8(jsdom@20.0.3)
 
   packages/vd-board:
-    dependencies:
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: ^4.4.0
+        version: 4.4.0(vite@4.5.0)(vue@3.3.6)
       '@vue-dapp/core':
         specifier: workspace:^
         version: link:../core
       pinia:
         specifier: ^2.1.7
         version: 2.1.7(typescript@5.2.2)(vue@3.3.6)
-      vue:
-        specifier: ^3.3.6
-        version: 3.3.6(typescript@5.2.2)
-    devDependencies:
-      '@vitejs/plugin-vue':
-        specifier: ^4.4.0
-        version: 4.4.0(vite@4.5.0)(vue@3.3.6)
       typescript:
         specifier: ^5.1.3
         version: 5.2.2
@@ -464,6 +460,9 @@ importers:
       vite-plugin-style-inject:
         specifier: ^0.0.1
         version: 0.0.1(vite@4.5.0)
+      vue:
+        specifier: ^3.3.6
+        version: 3.3.6(typescript@5.2.2)
       vue-tsc:
         specifier: ^0.29.8
         version: 0.29.8(typescript@5.2.2)
@@ -11835,7 +11834,6 @@ packages:
       typescript: 5.2.2
       vue: 3.3.6(typescript@5.2.2)
       vue-demi: 0.14.6(vue@3.3.6)
-    dev: false
 
   /pinia@2.1.7(vue@3.3.6):
     resolution: {integrity: sha512-+C2AHFtcFqjPih0zpYuvof37SFxMQ7OEG2zV9jRI12i9BOy3YQVAHwdKtyyc8pDcDyIc33WCIsZaCFWU7WWxGQ==}


### PR DESCRIPTION
- There're still some bugs and issues that need to be resolved.
- Updates on the progress of vue-dapp v1 will be posted in this v1 branch, and the main branch will follow up depending on the situation.
- `vue-dapp@1.0.0-alpha.2` has been released and is available for testing at [nuxt-dapp](https://github.com/vu3th/nuxt-dapp)
- Preliminary thoughts on v1 are as follows (updates to come soon):
    - vue-dapp v1 is designed for developers using Vue3 and Nuxt3, with the expectation that developers will install Pinia for state management.
    - It aims to be compatible whether developers use ethers, viem, or web3.js
    - All wallet providers can be included as part of the monorepo package for developers to maintain or extend it.
- If you encounter any issue or there's any wish feature, please feel free to let me know 🤓

## Reference
- #141 