### PR TITLE
Feat/enable dapp browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,90 +46,59 @@
 <img src="https://github.com/vu3th/vue-dapp/blob/main/app/public/images/overview.png" alt="Vue Dapp Overview" style="max-width:100%;" width="800">
 
 
-## Installation
+## Getting Started
 
-Minimum
-```bash
-npm install pinia @vue-dapp/core
-```
+### SPA with Vite
 
-With the wallet modal
 ```bash
 npm install pinia @vue-dapp/core @vue-dapp/modal
 ```
 
-Maximum
-```bash
-npm install pinia @vue-dapp/core @vue-dapp/modal @vue-dapp/walletconnect @vue-dapp/coinbase
+```ts [main.ts]
+import { createPinia } from 'pinia'
+app.use(createPinia())
 ```
-
-## Example
 
 ```vue
 <script lang="ts" setup>
-import {
-	useVueDapp,
-	BrowserWalletConnector,
-	VueDappProvider,
-	type ConnWallet,
-} from '@vue-dapp/core'
-import { VueDappModal } from '@vue-dapp/modal'
-import '@vue-dapp/modal/dist/style.css' // make sure to add css for the modal
+import { BrowserWalletConnector, useVueDapp } from '@vue-dapp/core'
+import { VueDappModal, useVueDappModal } from '@vue-dapp/modal'
+import '@vue-dapp/modal/dist/style.css'
 
-const { status, isConnected, address, chainId, error, disconnect, addConnector } = useVueDapp()
+const { addConnectors, isConnected, wallet, disconnect } = useVueDapp()
 
-const isModalOpen = ref(false)
+addConnectors([new BrowserWalletConnector()])
 
-function onClickConnectBtn() {
+function onClickConnectButton() {
 	if (isConnected.value) disconnect()
-	else isModalOpen.value = true
-}
-
-if (process.client) { // only when using Nuxt 3
-	addConnector(new BrowserWalletConnector())
-}
-
-function handleConnect(wallet: ConnWallet) {
-	console.log('handleConnect', wallet)
-	
-	// example with ethers v6
-	const ethersProvider = new ethers.providers.Web3Provider(provider)
-	const signer = await ethersProvider.getSigner()
-
-	dappStore.setUser({
-		address,
-		signer: markRaw(signer),
-		chainId,
-	})
-}
-
-function handleDisconnect() {
-	console.log('handleDisconnect')
-
-	// example
-	dappStore.resetUser()
+	else useVueDappModal().open()
 }
 </script>
 
 <template>
-	<div>
-		<VueDappProvider @connect="handleConnect" @disconnect="handleDisconnect">
-			<button @click="onClickConnectBtn">{{ isConnected ? 'Disconnect' : 'Connect' }}</button>
+	<button @click="onClickConnectButton">{{ isConnected ? 'Disconnect' : 'Connect' }}</button>
 
-			<div>status: {{ status }}</div>
-			<div>isConnected: {{ isConnected }}</div>
-			<div>error: {{ error }}</div>
+	<div>status: {{ wallet.status }}</div>
+	<div>isConnected: {{ isConnected }}</div>
+	<div>error: {{ wallet.error }}</div>
 
-			<div v-if="isConnected">
-				<div>chainId: {{ chainId }}</div>
-				<div>address: {{ address }}</div>
-			</div>
-
-			<VueDappModal v-model="isModalOpen" dark auto-connect />
-		</VueDappProvider>
+	<div v-if="isConnected">
+		<div>chainId: {{ wallet.chainId }}</div>
+		<div>address: {{ wallet.address }}</div>
 	</div>
-</template>
 
+	<VueDappModal dark auto-connect />
+</template>
+```
+
+### SSR with Nuxt 3
+
+```bash
+npm install pinia @pinia/nuxt @vue-dapp/core @vue-dapp/nuxt @vue-dapp/modal
+```
+
+```ts
+modules: ['@pinia/nuxt', '@vue-dapp/nuxt']
 ```
 
 ## Examples
@@ -140,9 +109,11 @@ function handleDisconnect() {
 ## Development
 
 ```
+pnpm i
 pnpm build
-pnpm dev
 pnpm -F core watch
+pnpm -F modal watch
+pnpm dev
 ```
 
 

--- a/app/app.vue
+++ b/app/app.vue
@@ -71,7 +71,7 @@ const hideConnectingModal = computed(() => {
 
 			<NuxtPage />
 
-			<VueDappModal autoConnect :hideConnectingModal="hideConnectingModal"> </VueDappModal>
+			<VueDappModal :hideConnectingModal="hideConnectingModal"> </VueDappModal>
 		</NuxtLayout>
 	</n-config-provider>
 </template>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -98,7 +98,7 @@ const items = computed<Item[]>(() => [
 				<p v-if="wallet.status === 'connected'">Disconnect</p>
 			</n-button>
 
-			<p class="text-red-500" v-if="wallet.error">{{ wallet.error }}</p>
+			<p class="text-red-500 text-center" v-if="wallet.error">{{ wallet.error }}</p>
 
 			<ClientOnly>
 				<Vue3EasyDataTable

--- a/app/pages/userAgent.vue
+++ b/app/pages/userAgent.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+const userAgent = ref('')
+
+onMounted(() => {
+	userAgent.value = navigator.userAgent
+})
+
+function alertUserAgent() {
+	alert(navigator.userAgent)
+}
+</script>
+
+<template>
+	<div>
+		<div>
+			{{ userAgent }}
+		</div>
+
+		<button @click="alertUserAgent">Alert userAgent</button>
+	</div>
+</template>
+
+<style lang="scss"></style>

--- a/packages/core/src/browserWalletConnector.ts
+++ b/packages/core/src/browserWalletConnector.ts
@@ -36,9 +36,22 @@ export class BrowserWalletConnector extends Connector<EIP1193Provider, BrowserWa
 	}
 
 	async connect(options?: ConnectOptions) {
-		const { timeout, rdns } = options ?? { timeout: undefined, rdns: undefined }
+		const { timeout, rdns, isWindowEthereum } = options ?? {
+			timeout: undefined,
+			rdns: undefined,
+			isWindowEthereum: false,
+		}
 
-		const { info, provider } = this.getProvider(rdns)
+		let provider, info
+
+		if (isWindowEthereum) {
+			provider = this.getWindowEthereumProvider()
+			if (!provider) throw new ProviderNotFoundError('window.ethereum not found')
+		} else {
+			const { provider: _provider, info: _info } = this.getProvider(rdns)
+			provider = _provider
+			info = _info
+		}
 
 		let accounts, chainId
 
@@ -75,6 +88,13 @@ export class BrowserWalletConnector extends Connector<EIP1193Provider, BrowserWa
 			chainId,
 			info,
 		}
+	}
+
+	getWindowEthereumProvider(): EIP1193Provider | null {
+		if (typeof window !== 'undefined' && !!window.ethereum) {
+			return window.ethereum
+		}
+		return null
 	}
 
 	getProvider(rdns?: RDNS | string): EIP6963ProviderDetail {

--- a/packages/core/src/browserWalletConnector.ts
+++ b/packages/core/src/browserWalletConnector.ts
@@ -35,16 +35,6 @@ export class BrowserWalletConnector extends Connector<EIP1193Provider, BrowserWa
 		useEIP6963().subscribe()
 	}
 
-	static async checkConnection(RDNS: string | RDNS) {
-		if (typeof window !== 'undefined' && !!window.ethereum) {
-			const { provider } = this.getProvider(RDNS)
-			if ((await provider.request({ method: 'eth_accounts' })).length !== 0) {
-				return true
-			}
-		}
-		return false
-	}
-
 	async connect(options?: ConnectOptions) {
 		const { timeout, rdns } = options ?? { timeout: undefined, rdns: undefined }
 
@@ -88,10 +78,6 @@ export class BrowserWalletConnector extends Connector<EIP1193Provider, BrowserWa
 	}
 
 	getProvider(rdns?: RDNS | string): EIP6963ProviderDetail {
-		return BrowserWalletConnector.getProvider(rdns)
-	}
-
-	static getProvider(rdns?: RDNS | string): EIP6963ProviderDetail {
 		const { providerDetails } = useEIP6963()
 		if (providerDetails.value.length < 1) throw new ProviderNotFoundError('providerDetails.length < 1')
 

--- a/packages/core/src/services/connect.ts
+++ b/packages/core/src/services/connect.ts
@@ -111,10 +111,7 @@ export function useConnect(pinia?: any) {
 		if (!bwConnector || !rdns) return
 
 		try {
-			const isConnected = await BrowserWalletConnector.checkConnection(rdns)
-			if (isConnected) {
-				await connectTo(bwConnector.name, { rdns })
-			}
+			await connectTo(bwConnector.name, { rdns })
 		} catch (err: any) {
 			throw new AutoConnectError(err)
 		}

--- a/packages/core/src/services/connect.ts
+++ b/packages/core/src/services/connect.ts
@@ -99,18 +99,19 @@ export function useConnect(pinia?: any) {
 		}
 	}
 
+	const isWindowEthereumAvailable = typeof window !== 'undefined' && !!window.ethereum
+
 	async function autoConnect(rdns?: RDNS | string, isWindowEthereum = false) {
-		const connectorName = 'BrowserWallet'
-		const bwConnector = walletStore.connectors.find(conn => conn.name === connectorName)
-		if (!bwConnector) return
+		const browserWallet = walletStore.connectors.find(conn => conn.name === 'BrowserWallet')
+		if (!browserWallet) return
 
 		let options = {}
 
 		if (isWindowEthereum) {
+			if (!isWindowEthereumAvailable) return
 			options = { isWindowEthereum }
 		} else {
 			const lastRdns = getLastConnectedBrowserWallet()
-			if (!lastRdns) return
 
 			rdns = rdns || lastRdns
 			if (!rdns) return
@@ -119,13 +120,15 @@ export function useConnect(pinia?: any) {
 		}
 
 		try {
-			await connectTo(bwConnector.name, options)
+			await connectTo(browserWallet.name, options)
 		} catch (err: any) {
 			throw new AutoConnectError(err)
 		}
 	}
 
 	return {
+		isWindowEthereumAvailable,
+
 		wallet: readonly(walletStore.wallet),
 
 		status: computed(() => walletStore.wallet.status),

--- a/packages/core/src/types/connector.ts
+++ b/packages/core/src/types/connector.ts
@@ -12,6 +12,7 @@ export type ConnectorData<Provider = any> = {
 
 export type ConnectOptions = {
 	rdns?: string | RDNS
+	isWindowEthereum?: boolean
 	timeout?: number
 }
 

--- a/packages/core/src/utils/assert.ts
+++ b/packages/core/src/utils/assert.ts
@@ -6,9 +6,9 @@ export function assertConnected(wallet: Wallet, errMsg?: string): asserts wallet
 	if (!wallet.connectorName) throw new AssertConnectedError(errMsg + ' - connectorName')
 	if (!wallet.provider) throw new AssertConnectedError(errMsg + ' - provider')
 
-	if (wallet.connectorName === 'BrowserWallet') {
-		if (!wallet.providerInfo) throw new AssertConnectedError(errMsg + ' - providerInfo')
-	}
+	// if (wallet.connectorName === 'BrowserWallet') {
+	// 	if (!wallet.providerInfo) throw new AssertConnectedError(errMsg + ' - providerInfo')
+	// }
 	if (!wallet.connector) throw new AssertConnectedError(errMsg + ' - connector')
 	if (!wallet.address) throw new AssertConnectedError(errMsg + ' - address')
 	if (!wallet.chainId) throw new AssertConnectedError(errMsg + ' - chainId')

--- a/packages/modal/src/VueDappModal.vue
+++ b/packages/modal/src/VueDappModal.vue
@@ -38,10 +38,18 @@ const modalOpen = computed(() => props.modelValue ?? store.isModalOpen)
 
 const isAutoConnecting = ref(false)
 
-const { connectors, connectTo, autoConnect, status, providerDetails, hasConnector, disconnect } = useVueDapp()
+const {
+	isWindowEthereumAvailable,
+	connectors,
+	connectTo,
+	autoConnect,
+	status,
+	providerDetails,
+	hasConnector,
+	disconnect,
+} = useVueDapp()
 
 // ============================ feat: autoConnect ============================
-
 onMounted(async () => {
 	if (props.autoConnect) {
 		try {
@@ -59,27 +67,13 @@ onMounted(async () => {
 	}
 })
 
-// Check whether the browser is within a mobile app (such as a WebView) rather than a standalone mobile browser like Chrome App
-function isMobileAppBrowser() {
-	const userAgent = navigator.userAgent
-
-	// for ios
-	if (!userAgent.includes('Safari/') && userAgent.includes('Mobile/')) {
-		return true
-	}
-
-	// for android
-	if (userAgent.includes('wv') || userAgent.includes('WebView')) {
-		return true
-	}
-
-	return false
-}
-
 watch(modalOpen, async () => {
-	// ============================ feat: connect to window.ethereum if there's no EIP-6963 providers ============================
+	// ============================ feat: connect to window.ethereum if window.ethereum is available and there's no EIP-6963 providers ============================
 	if (modalOpen.value && providerDetails.value.length === 0 && isMobileAppBrowser()) {
-		await onClickWallet('BrowserWallet', undefined, true)
+		if (isWindowEthereumAvailable) {
+			await onClickWallet('BrowserWallet', undefined, true)
+		}
+		return
 	}
 
 	// ============================ feat: auto click BrowserWallet if it's the only connector ============================
@@ -106,6 +100,23 @@ async function onClickWallet(connName: ConnectorName, rdns?: RDNS | string, isWi
 
 function onClickCancelConnecting() {
 	disconnect()
+}
+
+// Check whether the browser is within a mobile app (such as a WebView) rather than a standalone mobile browser like Chrome App
+function isMobileAppBrowser() {
+	const userAgent = navigator.userAgent
+
+	// for ios
+	if (!userAgent.includes('Safari/') && userAgent.includes('Mobile/')) {
+		return true
+	}
+
+	// for android
+	if (userAgent.includes('wv') || userAgent.includes('WebView')) {
+		return true
+	}
+
+	return false
 }
 
 const vClickOutside = {

--- a/packages/modal/src/VueDappModal.vue
+++ b/packages/modal/src/VueDappModal.vue
@@ -74,7 +74,7 @@ async function onClickWallet(connName: ConnectorName, rdns?: RDNS | string) {
 	try {
 		closeModal()
 		// throw new Error('test connect error')
-		await connectTo(connName, { rdns })
+		await connectTo(connName, { rdns, isWindowEthereum: true })
 	} catch (err: any) {
 		emit('connectError', err)
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,7 +97,7 @@ importers:
         version: 0.6.8(nuxt@3.10.3)(rollup@4.14.3)(vite@5.2.9)(vue@3.4.21)
       pinia:
         specifier: ^2.1.7
-        version: 2.1.7(typescript@5.3.3)(vue@3.4.21)
+        version: 2.1.7(vue@3.4.21)
       siwe:
         specifier: ^2.1.4
         version: 2.1.4(ethers@6.10.0)
@@ -125,7 +125,7 @@ importers:
         version: 10.4.17(postcss@8.4.33)
       nuxt:
         specifier: ^3.10.3
-        version: 3.10.3(@unocss/reset@0.59.3)(eslint@8.56.0)(floating-vue@5.2.2)(rollup@4.14.3)(sass@1.70.0)(unocss@0.59.3)(vite@5.2.9)
+        version: 3.10.3(@unocss/reset@0.59.3)(floating-vue@5.2.2)(rollup@4.14.3)(sass@1.70.0)(unocss@0.59.3)(vite@5.2.9)
       postcss:
         specifier: ^8.4.33
         version: 8.4.33
@@ -146,7 +146,7 @@ importers:
         version: 0.19.0(rollup@4.14.3)(vite@5.2.9)
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.3.3)
+        version: 3.4.21
       vue-router:
         specifier: ^4.2.5
         version: 4.2.5(vue@3.4.21)
@@ -293,6 +293,7 @@ packages:
   /@aashutoshrathi/word-wrap@1.2.6:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /@adraffy/ens-normalize@1.10.0:
     resolution: {integrity: sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==}
@@ -900,7 +901,7 @@ packages:
     peerDependencies:
       vue: ^3.0.11
     dependencies:
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
 
   /@csstools/cascade-layer-name-parser@1.0.7(@csstools/css-parser-algorithms@2.5.0)(@csstools/css-tokenizer@2.2.3):
     resolution: {integrity: sha512-9J4aMRJ7A2WRjaRLvsMeWrL69FmEuijtiW1XlK/sG+V0UJiHVYUyvj9mY4WAXfU/hGIiGOgL8e0jJcRyaZTjDQ==}
@@ -1346,10 +1347,12 @@ packages:
     dependencies:
       eslint: 8.56.0
       eslint-visitor-keys: 3.4.3
+    dev: true
 
   /@eslint-community/regexpp@4.10.0:
     resolution: {integrity: sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    dev: true
 
   /@eslint/eslintrc@2.1.4:
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
@@ -1366,10 +1369,12 @@ packages:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@eslint/js@8.56.0:
     resolution: {integrity: sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
 
   /@ethers-ext/provider-multicall@6.0.0-beta.1:
     resolution: {integrity: sha512-Q/IV8oWq6Ih4VU2AzTNR57aEElNdMq3cvtlFR+3G+IJsqyTXbrwyK2NbW9qHimh77A0FE8xkOgBl8UTYP3BHcA==}
@@ -1406,13 +1411,16 @@ packages:
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@humanwhocodes/module-importer@1.0.1:
     resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
     engines: {node: '>=12.22'}
+    dev: true
 
   /@humanwhocodes/object-schema@2.0.2:
     resolution: {integrity: sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==}
+    dev: true
 
   /@hutson/parse-repository-url@3.0.2:
     resolution: {integrity: sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==}
@@ -1447,7 +1455,7 @@ packages:
       vue: '>=3'
     dependencies:
       '@iconify/types': 2.0.0
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
     dev: false
 
   /@intlify/bundle-utils@7.5.1(vue-i18n@9.13.1):
@@ -2081,7 +2089,7 @@ packages:
       ufo: 1.5.3
       unist-util-stringify-position: 4.0.0
       unstorage: 1.10.2(ioredis@5.3.2)
-      ws: 8.16.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      ws: 8.16.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -2118,7 +2126,7 @@ packages:
       '@nuxt/kit': 3.9.3(rollup@4.14.3)
       '@nuxt/schema': 3.9.3(rollup@4.14.3)
       execa: 7.2.0
-      nuxt: 3.10.3(@unocss/reset@0.59.3)(eslint@8.56.0)(floating-vue@5.2.2)(rollup@4.14.3)(sass@1.70.0)(unocss@0.59.3)(vite@5.2.9)
+      nuxt: 3.10.3(@unocss/reset@0.59.3)(floating-vue@5.2.2)(rollup@4.14.3)(sass@1.70.0)(unocss@0.59.3)(vite@5.2.9)
       vite: 5.2.9(sass@1.70.0)
     transitivePeerDependencies:
       - rollup
@@ -2150,7 +2158,7 @@ packages:
       '@nuxt/kit': 3.11.2(rollup@4.14.3)
       '@nuxt/schema': 3.11.2(rollup@4.14.3)
       execa: 7.2.0
-      nuxt: 3.10.3(@unocss/reset@0.59.3)(eslint@8.56.0)(floating-vue@5.2.2)(rollup@4.14.3)(sass@1.70.0)(unocss@0.59.3)(vite@5.2.9)
+      nuxt: 3.10.3(@unocss/reset@0.59.3)(floating-vue@5.2.2)(rollup@4.14.3)(sass@1.70.0)(unocss@0.59.3)(vite@5.2.9)
       vite: 5.2.9(sass@1.70.0)
     transitivePeerDependencies:
       - rollup
@@ -2299,7 +2307,7 @@ packages:
       launch-editor: 2.6.1
       local-pkg: 0.5.0
       magicast: 0.3.4
-      nuxt: 3.10.3(@unocss/reset@0.59.3)(eslint@8.56.0)(floating-vue@5.2.2)(rollup@4.14.3)(sass@1.70.0)(unocss@0.59.3)(vite@5.2.9)
+      nuxt: 3.10.3(@unocss/reset@0.59.3)(floating-vue@5.2.2)(rollup@4.14.3)(sass@1.70.0)(unocss@0.59.3)(vite@5.2.9)
       nypm: 0.3.8
       ohash: 1.1.3
       pacote: 17.0.6
@@ -2316,7 +2324,7 @@ packages:
       vite-plugin-inspect: 0.8.3(@nuxt/kit@3.11.2)(rollup@4.14.3)(vite@5.2.9)
       vite-plugin-vue-inspector: 4.0.2(vite@5.2.9)
       which: 3.0.1
-      ws: 8.16.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
+      ws: 8.16.0
     transitivePeerDependencies:
       - '@unocss/reset'
       - '@vue/composition-api'
@@ -2897,7 +2905,7 @@ packages:
   /@nuxt/ui-templates@1.3.3:
     resolution: {integrity: sha512-3BG5doAREcD50dbKyXgmjD4b1GzY8CUy3T41jMhHZXNDdaNwOd31IBq+D6dV00OSrDVhzrTVj0IxsUsnMyHvIQ==}
 
-  /@nuxt/vite-builder@3.10.3(eslint@8.56.0)(rollup@4.14.3)(sass@1.70.0)(vue@3.4.21):
+  /@nuxt/vite-builder@3.10.3(rollup@4.14.3)(sass@1.70.0)(vue@3.4.21):
     resolution: {integrity: sha512-BqkbrYkEk1AVUJleofbqTRV+ltf2p1CDjGDK78zENPCgrSABlj4F4oK8rze8vmRY5qoH7kMZxgMa2dXVXCp6OA==}
     engines: {node: ^14.18.0 || >=16.10.0}
     peerDependencies:
@@ -2935,8 +2943,8 @@ packages:
       unplugin: 1.10.1
       vite: 5.2.9(sass@1.70.0)
       vite-node: 1.5.0(sass@1.70.0)
-      vite-plugin-checker: 0.6.4(eslint@8.56.0)(vite@5.2.9)
-      vue: 3.4.21(typescript@5.3.3)
+      vite-plugin-checker: 0.6.4(vite@5.2.9)
+      vue: 3.4.21
       vue-bundle-renderer: 2.0.0
     transitivePeerDependencies:
       - '@types/node'
@@ -3605,7 +3613,7 @@ packages:
     resolution: {integrity: sha512-6wT6TqY81n+7/x3Yhf0yfaJVKkZU42AGqOR0T3+UvChcaOJhSma7OWPN64v+ptYlznat+fS1VTwNAcbi2lzHnw==}
     dependencies:
       '@nuxt/kit': 3.9.3(rollup@4.14.3)
-      pinia: 2.1.7(typescript@5.3.3)(vue@3.4.21)
+      pinia: 2.1.7(vue@3.4.21)
     transitivePeerDependencies:
       - '@vue/composition-api'
       - rollup
@@ -4753,7 +4761,7 @@ packages:
       '@unhead/shared': 1.9.5
       hookable: 5.5.3
       unhead: 1.9.5
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
 
   /@unhead/vue@1.9.5(vue@3.4.23):
     resolution: {integrity: sha512-L3yDB6Mwm92gJNPqZApMwfGluS0agR0HIizkXCKKz3WkZ+ef/negMwTNGpTtd+uqh/+hSyG73Bl4yySuPsD4nA==}
@@ -5070,7 +5078,7 @@ packages:
       '@babel/plugin-transform-typescript': 7.24.4(@babel/core@7.24.4)
       '@vue/babel-plugin-jsx': 1.2.1(@babel/core@7.24.4)
       vite: 5.2.9(sass@1.70.0)
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
     transitivePeerDependencies:
       - supports-color
 
@@ -5120,7 +5128,7 @@ packages:
       vue: ^3.2.25
     dependencies:
       vite: 5.2.9(sass@1.70.0)
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
 
   /@vitejs/plugin-vue@5.0.4(vite@5.2.9)(vue@3.4.23):
     resolution: {integrity: sha512-WS3hevEszI6CEVEx28F8RjTX97k3KsrcY6kvTg7+Whm5y3oYvcqzVeGCU3hxSAn4uY2CLCkeokkGKpoctccilQ==}
@@ -5287,7 +5295,7 @@ packages:
       ast-kit: 0.11.3(rollup@4.14.3)
       local-pkg: 0.5.0
       magic-string-ast: 0.3.0
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
     transitivePeerDependencies:
       - rollup
 
@@ -5414,7 +5422,7 @@ packages:
       '@vue/devtools-ui': 7.0.27(@unocss/reset@0.59.3)(floating-vue@5.2.2)(unocss@0.59.3)(vue@3.4.21)
       perfect-debounce: 1.0.0
       splitpanes: 3.1.5
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
       vue-virtual-scroller: 2.0.0-beta.8(vue@3.4.21)
     transitivePeerDependencies:
       - '@unocss/reset'
@@ -5503,7 +5511,7 @@ packages:
       mitt: 3.0.1
       perfect-debounce: 1.0.0
       speakingurl: 14.0.1
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
 
   /@vue/devtools-kit@7.0.27(vue@3.4.23):
     resolution: {integrity: sha512-/A5xM38pPCFX5Yhl/lRFAzjyK6VNsH670nww2WbjFKWqlu3I+lMxWKzQkCW6A1V8bduITgl2kHORfg2gTw6QaA==}
@@ -5539,7 +5547,7 @@ packages:
       floating-vue: 5.2.2(vue@3.4.21)
       focus-trap: 7.5.4
       unocss: 0.59.3(postcss@8.4.33)(rollup@4.14.3)(vite@5.2.9)
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
     transitivePeerDependencies:
       - '@vue/composition-api'
       - async-validator
@@ -5655,7 +5663,7 @@ packages:
     dependencies:
       '@vue/compiler-ssr': 3.4.21
       '@vue/shared': 3.4.21
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
 
   /@vue/server-renderer@3.4.23(vue@3.4.23):
     resolution: {integrity: sha512-LDwGHtnIzvKFNS8dPJ1SSU5Gvm36p2ck8wCZc52fc3k/IfjKcwCyrWEf0Yag/2wTFUBXrqizfhK9c/mC367dXQ==}
@@ -5664,7 +5672,7 @@ packages:
     dependencies:
       '@vue/compiler-ssr': 3.4.23
       '@vue/shared': 3.4.23
-      vue: 3.4.23(typescript@5.3.3)
+      vue: 3.4.23
 
   /@vue/shared@3.4.10:
     resolution: {integrity: sha512-C0mIVhwW1xQLMFyqMJxnhq6fWyE02lCgcE+TDdtGpg6B3H6kh/0YcqS54qYc76UJNlWegf3VgsLqgk6D9hBmzQ==}
@@ -5741,7 +5749,7 @@ packages:
       '@unhead/schema': 1.9.5
       '@unhead/ssr': 1.9.5
       '@unhead/vue': 1.9.5(vue@3.4.21)
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
     dev: false
 
   /@vueuse/integrations@10.9.0(focus-trap@7.5.4)(vue@3.4.21):
@@ -5859,7 +5867,7 @@ packages:
       '@vueuse/core': 10.7.2(vue@3.4.21)
       '@vueuse/metadata': 10.7.2
       local-pkg: 0.5.0
-      nuxt: 3.10.3(@unocss/reset@0.59.3)(eslint@8.56.0)(floating-vue@5.2.2)(rollup@4.14.3)(sass@1.70.0)(unocss@0.59.3)(vite@5.2.9)
+      nuxt: 3.10.3(@unocss/reset@0.59.3)(floating-vue@5.2.2)(rollup@4.14.3)(sass@1.70.0)(unocss@0.59.3)(vite@5.2.9)
       vue-demi: 0.14.6(vue@3.4.21)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -5877,7 +5885,7 @@ packages:
       '@vueuse/core': 10.9.0(vue@3.4.21)
       '@vueuse/metadata': 10.9.0
       local-pkg: 0.5.0
-      nuxt: 3.10.3(@unocss/reset@0.59.3)(eslint@8.56.0)(floating-vue@5.2.2)(rollup@4.14.3)(sass@1.70.0)(unocss@0.59.3)(vite@5.2.9)
+      nuxt: 3.10.3(@unocss/reset@0.59.3)(floating-vue@5.2.2)(rollup@4.14.3)(sass@1.70.0)(unocss@0.59.3)(vite@5.2.9)
       vue-demi: 0.14.7(vue@3.4.21)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -6403,6 +6411,7 @@ packages:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+    dev: true
 
   /ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -7070,6 +7079,7 @@ packages:
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+    dev: true
 
   /camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
@@ -8020,6 +8030,7 @@ packages:
 
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+    dev: true
 
   /deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -8210,6 +8221,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       esutils: 2.0.3
+    dev: true
 
   /doctypes@1.1.0:
     resolution: {integrity: sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==}
@@ -8533,6 +8545,7 @@ packages:
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+    dev: true
 
   /escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
@@ -8604,6 +8617,7 @@ packages:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
+    dev: true
 
   /eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
@@ -8654,6 +8668,7 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -8673,12 +8688,14 @@ packages:
     engines: {node: '>=0.10'}
     dependencies:
       estraverse: 5.3.0
+    dev: true
 
   /esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
     engines: {node: '>=4.0'}
     dependencies:
       estraverse: 5.3.0
+    dev: true
 
   /estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
@@ -8871,6 +8888,7 @@ packages:
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+    dev: true
 
   /fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
@@ -8891,9 +8909,11 @@ packages:
 
   /fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+    dev: true
 
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+    dev: true
 
   /fast-redact@3.3.0:
     resolution: {integrity: sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==}
@@ -8924,6 +8944,7 @@ packages:
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
       flat-cache: 3.2.0
+    dev: true
 
   /file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -8973,6 +8994,7 @@ packages:
       flatted: 3.2.9
       keyv: 4.5.4
       rimraf: 3.0.2
+    dev: true
 
   /flat@5.0.2:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
@@ -8986,6 +9008,7 @@ packages:
 
   /flatted@3.2.9:
     resolution: {integrity: sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==}
+    dev: true
 
   /flatted@3.3.1:
     resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
@@ -9015,7 +9038,7 @@ packages:
         optional: true
     dependencies:
       '@floating-ui/dom': 1.1.1
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
       vue-resize: 2.0.0-alpha.1(vue@3.4.21)
 
   /focus-trap@7.5.4:
@@ -9355,6 +9378,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
+    dev: true
 
   /globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -9411,6 +9435,7 @@ packages:
 
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+    dev: true
 
   /gzip-size@6.0.0:
     resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
@@ -9821,6 +9846,7 @@ packages:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+    dev: true
 
   /import-lazy@4.0.0:
     resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
@@ -10080,6 +10106,7 @@ packages:
   /is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
+    dev: true
 
   /is-path-inside@4.0.0:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
@@ -10362,6 +10389,7 @@ packages:
 
   /json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+    dev: true
 
   /json-parse-better-errors@1.0.2:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
@@ -10389,9 +10417,11 @@ packages:
 
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+    dev: true
 
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+    dev: true
 
   /json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
@@ -10456,6 +10486,7 @@ packages:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
     dependencies:
       json-buffer: 3.0.1
+    dev: true
 
   /keyvaluestorage-interface@1.0.0:
     resolution: {integrity: sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==}
@@ -10588,6 +10619,7 @@ packages:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+    dev: true
 
   /libnpmaccess@7.0.2:
     resolution: {integrity: sha512-vHBVMw1JFMTgEk15zRsJuSAg7QtGGHpUSEfnbcRL1/gTBag9iEfJbyjpDmdJmwMhvpoLoNBtdAUCdGnaP32hhw==}
@@ -11781,7 +11813,7 @@ packages:
       treemate: 0.3.11
       vdirs: 0.1.8(vue@3.4.21)
       vooks: 0.2.12(vue@3.4.21)
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
       vueuc: 0.4.58(vue@3.4.21)
     dev: false
 
@@ -11800,6 +11832,7 @@ packages:
 
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+    dev: true
 
   /negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
@@ -12248,7 +12281,7 @@ packages:
       - vue
     dev: false
 
-  /nuxt@3.10.3(@unocss/reset@0.59.3)(eslint@8.56.0)(floating-vue@5.2.2)(rollup@4.14.3)(sass@1.70.0)(unocss@0.59.3)(vite@5.2.9):
+  /nuxt@3.10.3(@unocss/reset@0.59.3)(floating-vue@5.2.2)(rollup@4.14.3)(sass@1.70.0)(unocss@0.59.3)(vite@5.2.9):
     resolution: {integrity: sha512-NchGNiiz9g/ErJAb462W/lpX2NqcXYb9hugySKWvLXNdrjeAPiJ2/7mhgwUSiZA9MpjuQg3saiEajr1zlRIOCg==}
     engines: {node: ^14.18.0 || >=16.10.0}
     hasBin: true
@@ -12267,7 +12300,7 @@ packages:
       '@nuxt/schema': 3.10.3(rollup@4.14.3)
       '@nuxt/telemetry': 2.5.4(rollup@4.14.3)
       '@nuxt/ui-templates': 1.3.3
-      '@nuxt/vite-builder': 3.10.3(eslint@8.56.0)(rollup@4.14.3)(sass@1.70.0)(vue@3.4.21)
+      '@nuxt/vite-builder': 3.10.3(rollup@4.14.3)(sass@1.70.0)(vue@3.4.21)
       '@unhead/dom': 1.9.5
       '@unhead/ssr': 1.9.5
       '@unhead/vue': 1.9.5(vue@3.4.21)
@@ -12312,7 +12345,7 @@ packages:
       unplugin: 1.10.1
       unplugin-vue-router: 0.7.0(rollup@4.14.3)(vue-router@4.3.0)(vue@3.4.21)
       untyped: 1.4.2
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
       vue-bundle-renderer: 2.0.0
       vue-devtools-stub: 0.1.0
       vue-router: 4.3.0(vue@3.4.21)
@@ -12719,6 +12752,7 @@ packages:
       levn: 0.4.1
       prelude-ls: 1.2.1
       type-check: 0.4.0
+    dev: true
 
   /ora@5.3.0:
     resolution: {integrity: sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==}
@@ -12924,6 +12958,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
+    dev: true
 
   /parse-asn1@5.1.6:
     resolution: {integrity: sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==}
@@ -13106,7 +13141,7 @@ packages:
     peerDependencies:
       pinia: ^2.0.0
     dependencies:
-      pinia: 2.1.7(typescript@5.3.3)(vue@3.4.21)
+      pinia: 2.1.7(vue@3.4.21)
     dev: false
 
   /pinia@2.1.7(typescript@5.3.3)(vue@3.4.21):
@@ -13125,6 +13160,24 @@ packages:
       typescript: 5.3.3
       vue: 3.4.21(typescript@5.3.3)
       vue-demi: 0.14.6(vue@3.4.21)
+    dev: true
+
+  /pinia@2.1.7(vue@3.4.21):
+    resolution: {integrity: sha512-+C2AHFtcFqjPih0zpYuvof37SFxMQ7OEG2zV9jRI12i9BOy3YQVAHwdKtyyc8pDcDyIc33WCIsZaCFWU7WWxGQ==}
+    peerDependencies:
+      '@vue/composition-api': ^1.4.0
+      typescript: '>=4.4.4'
+      vue: ^2.6.14 || ^3.3.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      '@vue/devtools-api': 6.5.1
+      vue: 3.4.21
+      vue-demi: 0.14.6(vue@3.4.21)
+    dev: false
 
   /pino-abstract-transport@0.5.0:
     resolution: {integrity: sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==}
@@ -13822,6 +13875,7 @@ packages:
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+    dev: true
 
   /prettier-linter-helpers@1.0.0:
     resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
@@ -14421,6 +14475,7 @@ packages:
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+    dev: true
 
   /resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -15240,6 +15295,7 @@ packages:
   /strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+    dev: true
 
   /strip-literal@1.3.0:
     resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
@@ -15471,6 +15527,7 @@ packages:
 
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+    dev: true
 
   /thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -15674,6 +15731,7 @@ packages:
     engines: {node: '>= 0.8.0'}
     dependencies:
       prelude-ls: 1.2.1
+    dev: true
 
   /type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
@@ -15688,6 +15746,7 @@ packages:
   /type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
+    dev: true
 
   /type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
@@ -15720,6 +15779,7 @@ packages:
     resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
     engines: {node: '>=14.17'}
     hasBin: true
+    dev: true
 
   /typescript@5.4.5:
     resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
@@ -16084,7 +16144,7 @@ packages:
       minimatch: 9.0.3
       resolve: 1.22.8
       unplugin: 1.6.0
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -16463,7 +16523,7 @@ packages:
       vue: ^3.0.11
     dependencies:
       evtd: 0.2.4
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
     dev: false
 
   /vfile-location@5.0.2:
@@ -16630,7 +16690,7 @@ packages:
       vscode-uri: 3.0.8
     dev: true
 
-  /vite-plugin-checker@0.6.4(eslint@8.56.0)(vite@5.2.9):
+  /vite-plugin-checker@0.6.4(vite@5.2.9):
     resolution: {integrity: sha512-2zKHH5oxr+ye43nReRbC2fny1nyARwhxdm0uNYp/ERy4YvU9iZpNOsueoi/luXw5gnpqRSvjcEPxXbS153O2wA==}
     engines: {node: '>=14.16'}
     peerDependencies:
@@ -16666,7 +16726,6 @@ packages:
       chalk: 4.1.2
       chokidar: 3.6.0
       commander: 8.3.0
-      eslint: 8.56.0
       fast-glob: 3.3.2
       fs-extra: 11.2.0
       npm-run-path: 4.0.1
@@ -16976,7 +17035,7 @@ packages:
       vue: ^3.0.0
     dependencies:
       evtd: 0.2.4
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
     dev: false
 
   /vs-vue3-select@1.3.5(vue@3.4.21):
@@ -16984,7 +17043,7 @@ packages:
     peerDependencies:
       vue: 3.x
     dependencies:
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
     dev: false
 
   /vscode-css-languageservice@5.4.2:
@@ -17153,7 +17212,7 @@ packages:
       '@vue/composition-api':
         optional: true
     dependencies:
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
 
   /vue-demi@0.14.7(vue@3.4.21):
     resolution: {integrity: sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==}
@@ -17167,7 +17226,7 @@ packages:
       '@vue/composition-api':
         optional: true
     dependencies:
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
 
   /vue-demi@0.14.7(vue@3.4.23):
     resolution: {integrity: sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==}
@@ -17214,7 +17273,7 @@ packages:
       '@intlify/core-base': 9.13.1
       '@intlify/shared': 9.13.1
       '@vue/devtools-api': 6.6.1
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
     dev: false
 
   /vue-observe-visibility@2.0.0-alpha.1(vue@3.4.21):
@@ -17222,7 +17281,7 @@ packages:
     peerDependencies:
       vue: ^3.0.0
     dependencies:
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
 
   /vue-observe-visibility@2.0.0-alpha.1(vue@3.4.23):
     resolution: {integrity: sha512-flFbp/gs9pZniXR6fans8smv1kDScJ8RS7rEpMjhVabiKeq7Qz3D9+eGsypncjfIyyU84saU88XZ0zjbD6Gq/g==}
@@ -17237,7 +17296,7 @@ packages:
     peerDependencies:
       vue: ^3.0.0
     dependencies:
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
 
   /vue-resize@2.0.0-alpha.1(vue@3.4.23):
     resolution: {integrity: sha512-7+iqOueLU7uc9NrMfrzbG8hwMqchfVfSzpVlCMeJQe4pyibqyoifDNbKTZvwxZKDvGkB+PdFeKvnGZMoEb8esg==}
@@ -17253,7 +17312,7 @@ packages:
       vue: ^3.2.0
     dependencies:
       '@vue/devtools-api': 6.5.1
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
     dev: true
 
   /vue-router@4.3.0(vue@3.4.21):
@@ -17262,7 +17321,7 @@ packages:
       vue: ^3.2.0
     dependencies:
       '@vue/devtools-api': 6.6.1
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
 
   /vue-router@4.3.1(vue@3.4.21):
     resolution: {integrity: sha512-D0h3oyP6vp28BOvxv2hVpiqFTjTJizCf1BuMmCibc8UW0Ll/N80SWqDd/hqPMaZfzW1j+s2s+aTRyBIP9ElzOw==}
@@ -17270,7 +17329,7 @@ packages:
       vue: ^3.2.0
     dependencies:
       '@vue/devtools-api': 6.6.1
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
     dev: false
 
   /vue-router@4.3.1(vue@3.4.23):
@@ -17318,7 +17377,7 @@ packages:
       vue: ^3.2.0
     dependencies:
       mitt: 2.1.0
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
       vue-observe-visibility: 2.0.0-alpha.1(vue@3.4.21)
       vue-resize: 2.0.0-alpha.1(vue@3.4.21)
 
@@ -17336,10 +17395,24 @@ packages:
   /vue3-easy-data-table@1.5.47:
     resolution: {integrity: sha512-q0bZBlWIwQ3FIhB+F98ylFPfBJWiS3Xv7QqBe3xS5MbRNZP96RFjaQn7C0Pi0J/aaucNW8gFWxPyh9NESS1ehw==}
     dependencies:
-      vue: 3.4.23(typescript@5.3.3)
+      vue: 3.4.23
     transitivePeerDependencies:
       - typescript
     dev: false
+
+  /vue@3.4.21:
+    resolution: {integrity: sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@vue/compiler-dom': 3.4.21
+      '@vue/compiler-sfc': 3.4.21
+      '@vue/runtime-dom': 3.4.21
+      '@vue/server-renderer': 3.4.21(vue@3.4.21)
+      '@vue/shared': 3.4.21
 
   /vue@3.4.21(typescript@5.3.3):
     resolution: {integrity: sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==}
@@ -17355,6 +17428,21 @@ packages:
       '@vue/server-renderer': 3.4.21(vue@3.4.21)
       '@vue/shared': 3.4.21
       typescript: 5.3.3
+    dev: true
+
+  /vue@3.4.23:
+    resolution: {integrity: sha512-X1y6yyGJ28LMUBJ0k/qIeKHstGd+BlWQEOT40x3auJFTmpIhpbKLgN7EFsqalnJXq1Km5ybDEsp6BhuWKciUDg==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@vue/compiler-dom': 3.4.23
+      '@vue/compiler-sfc': 3.4.23
+      '@vue/runtime-dom': 3.4.23
+      '@vue/server-renderer': 3.4.23(vue@3.4.23)
+      '@vue/shared': 3.4.23
 
   /vue@3.4.23(typescript@5.3.3):
     resolution: {integrity: sha512-X1y6yyGJ28LMUBJ0k/qIeKHstGd+BlWQEOT40x3auJFTmpIhpbKLgN7EFsqalnJXq1Km5ybDEsp6BhuWKciUDg==}
@@ -17370,6 +17458,7 @@ packages:
       '@vue/server-renderer': 3.4.23(vue@3.4.23)
       '@vue/shared': 3.4.23
       typescript: 5.3.3
+    dev: true
 
   /vueuc@0.4.58(vue@3.4.21):
     resolution: {integrity: sha512-Wnj/N8WbPRSxSt+9ji1jtDHPzda5h2OH/0sFBhvdxDRuyCZbjGg3/cKMaKqEoe+dErTexG2R+i6Q8S/Toq1MYg==}
@@ -17383,7 +17472,7 @@ packages:
       seemly: 0.3.8
       vdirs: 0.1.8(vue@3.4.21)
       vooks: 0.2.12(vue@3.4.21)
-      vue: 3.4.21(typescript@5.3.3)
+      vue: 3.4.21
     dev: false
 
   /w3c-xmlserializer@5.0.0:
@@ -17618,6 +17707,18 @@ packages:
       utf-8-validate:
         optional: true
     dev: false
+
+  /ws@8.16.0:
+    resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   /ws@8.16.0(bufferutil@4.0.8)(utf-8-validate@5.0.10):
     resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}


### PR DESCRIPTION
- Test App: https://vue-dapp-git-feat-enable-dapp-browser-chnejohnsons-projects.vercel.app/
- #171 

## Specification

### isMobileAppBrowser & isWindowEthereumAvailable

`isMobileAppBrowser` can distinguish whether the page is opened in the mobile web browser.

Though even if it's a mobile web browser, it might not be a dapp browser, meaning it doesn't have `window.ethereum`.

- The wallet apps with a dapp browser that I've currently tested include:
    - Trust Wallet
    - Coinbase Wallet
    - MetaMask Wallet.
- You can use Telegram to test the mobile app browser without `window.ethereum`.
- Currently, testing has only been conducted on iPhone SE 2.


```ts
function isMobileAppBrowser() {
	const userAgent = navigator.userAgent

	// for ios
	if (!userAgent.includes('Safari/') && userAgent.includes('Mobile/')) {
		return true
	}

	// for android
	if (userAgent.includes('wv') || userAgent.includes('WebView')) {
		return true
	}

	return false
}
```

```ts
const isWindowEthereumAvailable = typeof window !== 'undefined' && !!window.ethereum
```


## `autoConnect` == true

When the page loads and initiates automatic connection, 

### isMobileAppBrowser == true

#### isWindowEthereumAvailable == true
It directly connects to `window.ethereum` .

#### isWindowEthereumAvailable == false
It doesn't execute `connectTo`.


### isMobileAppBrowser == false

it retrieves the RDNS of the last connected browser wallet from local storage and attempts to connect to it.

## `autoConnect` == false

When the modal is opened,

### isMobileAppBrowser == true

#### isWindowEthereumAvailable == true
It directly connect to `window.ethereum` without showing the modal.

#### isWindowEthereumAvailable == false
The modal will show the text "No wallet provider found 😔".


### isMobileAppBrowser == false

It displays a list of EIP-6963 providers. If there are no EIP-6963 providers, the modal will show the text "No wallet provider found 😔".


