### PR TITLE
fix: expose types for ts

### DIFF
--- a/packages/coinbase/package.json
+++ b/packages/coinbase/package.json
@@ -29,7 +29,8 @@
 	"exports": {
 		".": {
 			"import": "./dist/coinbase.js",
-			"require": "./dist/coinbase.umd.cjs"
+			"require": "./dist/coinbase.umd.cjs",
+			"types": "./dist/index.d.ts"
 		}
 	},
 	"publishConfig": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,8 @@
 	"exports": {
 		".": {
 			"import": "./dist/core.mjs",
-			"require": "./dist/core.umd.js"
+			"require": "./dist/core.umd.js",
+			"types": "./dist/index.d.ts"
 		}
 	},
 	"publishConfig": {

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -28,7 +28,8 @@
 	"exports": {
 		".": {
 			"import": "./dist/modal.mjs",
-			"require": "./dist/modal.umd.js"
+			"require": "./dist/modal.umd.js",
+			"types": "./dist/index.d.ts"
 		},
 		"./dist/style.css": "./dist/style.css"
 	},

--- a/packages/walletconnect/package.json
+++ b/packages/walletconnect/package.json
@@ -29,7 +29,8 @@
 	"exports": {
 		".": {
 			"import": "./dist/walletconnect.js",
-			"require": "./dist/walletconnect.umd.cjs"
+			"require": "./dist/walletconnect.umd.cjs",
+			"types": "./dist/index.d.ts"
 		}
 	},
 	"publishConfig": {


### PR DESCRIPTION
The `types` should be exported, so that `typescript` can resolve the types. Made it so that it's exported. `nuxt` package is working fine so did not PR change.

Currently when importing to a Nuxt project with default `tsconfig.json` setting results in this during `typecheck`.

```
Could not find a declaration file for module '@vue-dapp/modal'. '/node_modules/@vue-dapp/modal/dist/modal.mjs' implicitly has an 'any' type.
There are types at '/node_modules/@vue-dapp/modal/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports".
The '@vue-dapp/modal' library may need to update its package.json or typings.
```